### PR TITLE
Add --volume-as-number tag and update documentation

### DIFF
--- a/KOMGA_KAVITA_GUIDE.md
+++ b/KOMGA_KAVITA_GUIDE.md
@@ -114,6 +114,24 @@ Your current naming (`c001.cbz`, `c002.cbz`, etc.) works well. For optimal recog
 - ❌ Incorrect XML format (our tool prevents this)
 - ❌ Case sensitivity: must be exactly `ComicInfo.xml`
 
+## Volumes vs Chapters (The `<Number>` Tag)
+
+Because the `ComicInfo.xml` schema was originally designed for Western comic books, it relies on the `<Number>` tag to identify the specific **Issue** or **Chapter**.
+
+When you use `itagger` to generate metadata:
+
+- **Chapters (`--chapter` or `-t chapters`)**: `itagger` maps the chapter number directly to the `<Number>` tag and leaves `<Volume>` empty. This is exactly what Kavita and Komga expect for individual chapter files.
+- **Volumes (`--volume` or `-t volumes`)**: `itagger` maps the volume number to the `<Volume>` tag and leaves `<Number>` completely empty. This prevents readers like Kavita from incorrectly reading "Volume 5" as "Chapter 5".
+
+### Legacy / Override Behavior
+
+If your specific setup or obscure reading software requires the `<Number>` tag to be populated even for full volumes, you can use the `--volume-as-number` flag to override this standard behavior. This will copy the volume number into the `<Number>` tag:
+
+```bash
+# Example: Map Volume 1 to both <Volume>1</Volume> and <Number>1</Number>
+itagger embed /path/to/Elfen-Lied 30933 -t volumes --volume-as-number
+```
+
 ## Alternative: Volume-Based Structure
 
 If you prefer volume-based organization:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ Example:
 
 ```bash
 itagger generate --volume 1 --scan-info "My Scanlation Group" 105778
+
+# If you need the Volume number to also populate the <Number> tag:
+itagger generate --volume 1 --volume-as-number 105778
 ```
 
 This command generates a `ComicInfo.xml` file for volume 1 of the manga with AniList ID `105778` (Chainsaw Man) and includes the specified [scanlation group](https://anansi-project.github.io/docs/comicinfo/documentation#scaninformation) in the metadata.
@@ -187,26 +190,26 @@ with open("ComicInfo.xml", "w", encoding="utf-8") as f:
 
 The tool maps AniList data to ComicInfo.xml fields according to the schema:
 
-| ComicInfo Field   | Source                       | Description                                         |
-| ----------------- | ---------------------------- | --------------------------------------------------- |
-| `Title`           | Manga title + volume/chapter | Full title including volume/chapter info            |
-| `Series`          | Primary title                | Series name (English preferred, fallback to Romaji) |
-| `Number`          | Volume/Chapter               | Volume or chapter number                            |
-| `Count`           | Volume count                 | Total volumes in series                             |
-| `Volume`          | Volume number                | Specific volume number                              |
-| `Summary`         | Description                  | Cleaned description without HTML                    |
-| `Year/Month/Day`  | Start date                   | Publication start date                              |
-| `Writer`          | Staff with "Story" role      | Authors/writers                                     |
-| `Penciller`       | Staff with "Art" role        | Artists                                             |
-| `Publisher`       | Studios                      | Publishing studios                                  |
-| `Genre`           | Genres                       | Comma-separated genres                              |
-| `Tags`            | Tags (non-spoiler)           | Comma-separated tags                                |
-| `Web`             | Site URL                     | AniList page URL                                    |
-| `LanguageISO`     | Country of origin            | Language code (ja, ko, zh, etc.)                    |
-| `Manga`           | Country + format             | Reading direction (YesAndRightToLeft for JP)        |
-| `Characters`      | Main characters              | Main character names                                |
-| `AgeRating`       | Tags + adult flag            | Age appropriateness rating                          |
-| `CommunityRating` | Average score                | Rating converted to 0-5 scale                       |
+| ComicInfo Field   | Source                       | Description                                                  |
+| ----------------- | ---------------------------- | ------------------------------------------------------------ |
+| `Title`           | Manga title + volume/chapter | Full title including volume/chapter info                     |
+| `Series`          | Primary title                | Series name (English preferred, fallback to Romaji)          |
+| `Number`          | Chapter                      | Chapter number (unless overridden with `--volume-as-number`) |
+| `Count`           | Volume count                 | Total volumes in series                                      |
+| `Volume`          | Volume number                | Specific volume number                                       |
+| `Summary`         | Description                  | Cleaned description without HTML                             |
+| `Year/Month/Day`  | Start date                   | Publication start date                                       |
+| `Writer`          | Staff with "Story" role      | Authors/writers                                              |
+| `Penciller`       | Staff with "Art" role        | Artists                                                      |
+| `Publisher`       | Studios                      | Publishing studios                                           |
+| `Genre`           | Genres                       | Comma-separated genres                                       |
+| `Tags`            | Tags (non-spoiler)           | Comma-separated tags                                         |
+| `Web`             | Site URL                     | AniList page URL                                             |
+| `LanguageISO`     | Country of origin            | Language code (ja, ko, zh, etc.)                             |
+| `Manga`           | Country + format             | Reading direction (YesAndRightToLeft for JP)                 |
+| `Characters`      | Main characters              | Main character names                                         |
+| `AgeRating`       | Tags + adult flag            | Age appropriateness rating                                   |
+| `CommunityRating` | Average score                | Rating converted to 0-5 scale                                |
 
 ### Example Output
 

--- a/itagger/cli.py
+++ b/itagger/cli.py
@@ -5,9 +5,11 @@ Manga Tagger CLI
 A command-line tool to create and embed ComicInfo.xml files for manga using the AniList API.
 """
 
-import click
 import zipfile
 from pathlib import Path
+
+import click
+
 from .anilist_client import AniListClient
 from .comicinfo_generator import ComicInfoGenerator
 
@@ -61,7 +63,8 @@ def search(query: str, limit: int):
 @click.option('--volume', '-v', type=int, help='Volume number')
 @click.option('--chapter', '-c', type=str, help='Chapter number')
 @click.option('--scan-info', '-s', type=str, help='Scan information (e.g., scanlator name)')
-def generate(manga_id: int, output: str, volume: int, chapter: str, scan_info: str):
+@click.option('--volume-as-number', is_flag=True, help='Map volume number to the Number tag (legacy behavior)')
+def generate(manga_id: int, output: str, volume: int, chapter: str, scan_info: str, volume_as_number: bool):
     """Generate ComicInfo.xml for a specific manga."""
     client = AniListClient()
     generator = ComicInfoGenerator()
@@ -78,7 +81,9 @@ def generate(manga_id: int, output: str, volume: int, chapter: str, scan_info: s
         click.echo(f"Found: {manga.title_romaji}")
 
         # Generate ComicInfo.xml
-        comic_info = generator.generate_comic_info(manga=manga, volume=volume, chapter=chapter, scan_info=scan_info)
+        comic_info = generator.generate_comic_info(
+            manga=manga, volume=volume, chapter=chapter, scan_info=scan_info, volume_as_number=volume_as_number
+        )
 
         # Determine output path
         if not output:
@@ -101,7 +106,8 @@ def generate(manga_id: int, output: str, volume: int, chapter: str, scan_info: s
 @click.argument('query', type=str)
 @click.option('--output-dir', '-d', type=click.Path(), default='./output', help='Output directory')
 @click.option('--volumes', type=str, help='Volume range (e.g., 1-5 or 1,3,5)')
-def batch(query: str, output_dir: str, volumes: str):
+@click.option('--volume-as-number', is_flag=True, help='Map volume number to the Number tag (legacy behavior)')
+def batch(query: str, output_dir: str, volumes: str, volume_as_number: bool):
     """Generate ComicInfo.xml files for multiple volumes of a manga series."""
     client = AniListClient()
     generator = ComicInfoGenerator()
@@ -140,7 +146,7 @@ def batch(query: str, output_dir: str, volumes: str):
 
         # Generate ComicInfo.xml for each volume
         for volume in volume_list:
-            comic_info = generator.generate_comic_info(manga=manga, volume=volume)
+            comic_info = generator.generate_comic_info(manga=manga, volume=volume, volume_as_number=volume_as_number)
 
             filename = f"ComicInfo_Vol{volume:02d}.xml"
             file_path = output_path / filename
@@ -198,9 +204,17 @@ def _add_comicinfo_to_cbz(cbz_path: Path, comicinfo_content: str) -> bool:
 @click.option('--pattern', '-p', type=str, help='CBZ filename pattern (e.g., "c{:03d}.cbz" for c001.cbz, c002.cbz)')
 @click.option('--range', '-r', 'range_spec', type=str, help='Range of chapters/volumes (e.g., "1-10" or "1,3,5-8")')
 @click.option('--scan-info', '-s', type=str, help='Scan information to add to metadata')
+@click.option('--volume-as-number', is_flag=True, help='Map volume number to the Number tag (legacy behavior)')
 @click.option('--dry-run', is_flag=True, help='Show what would be processed without making changes')
 def embed(
-    cbz_dir: Path, manga_id: int, metadata_type: str, pattern: str, range_spec: str, scan_info: str, dry_run: bool
+    cbz_dir: Path,
+    manga_id: int,
+    metadata_type: str,
+    pattern: str,
+    range_spec: str,
+    scan_info: str,
+    volume_as_number: bool,
+    dry_run: bool,
 ):
     """Embed ComicInfo.xml metadata directly into CBZ files.
 
@@ -280,7 +294,9 @@ def embed(
             if metadata_type == 'chapters':
                 comic_info = generator.generate_comic_info(manga=manga, chapter=str(number), scan_info=scan_info)
             else:
-                comic_info = generator.generate_comic_info(manga=manga, volume=int(number), scan_info=scan_info)
+                comic_info = generator.generate_comic_info(
+                    manga=manga, volume=int(number), scan_info=scan_info, volume_as_number=volume_as_number
+                )
 
             if dry_run:
                 click.echo(f"📄 Would process: {filename}")

--- a/itagger/comicinfo_generator.py
+++ b/itagger/comicinfo_generator.py
@@ -71,6 +71,7 @@ class ComicInfoGenerator:
         volume: Optional[int] = None,
         chapter: Optional[str] = None,
         scan_info: Optional[str] = None,
+        volume_as_number: bool = False,
     ) -> ComicInfoData:
         """Create ComicInfoData from manga details."""
 
@@ -101,11 +102,16 @@ class ComicInfoGenerator:
         format_type = "Digital"  # Default for downloaded manga
         if manga.format == "ONE_SHOT":
             format_type = "One-Shot"
+            
+        # Determine number field
+        number_val = str(chapter) if chapter else None
+        if volume_as_number and volume:
+            number_val = str(volume)
 
         return ComicInfoData(
             title=title,
             series=manga.get_primary_title(),
-            number=str(volume) if volume else str(chapter) if chapter else None,
+            number=number_val,
             count=manga.volumes,
             volume=volume,
             summary=summary,
@@ -204,7 +210,8 @@ class ComicInfoGenerator:
         volume: Optional[int] = None,
         chapter: Optional[str] = None,
         scan_info: Optional[str] = None,
+        volume_as_number: bool = False,
     ) -> str:
         """Generate ComicInfo.xml content from manga details."""
-        comic_data = self.create_comic_info_data(manga, volume, chapter, scan_info)
+        comic_data = self.create_comic_info_data(manga, volume, chapter, scan_info, volume_as_number)
         return self.generate_comic_info_xml(comic_data)

--- a/itagger/comicinfo_generator.py
+++ b/itagger/comicinfo_generator.py
@@ -102,7 +102,7 @@ class ComicInfoGenerator:
         format_type = "Digital"  # Default for downloaded manga
         if manga.format == "ONE_SHOT":
             format_type = "One-Shot"
-            
+
         # Determine number field
         number_val = str(chapter) if chapter else None
         if volume_as_number and volume:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "itagger"
-version = "0.1.3"
+version = "0.1.4"
 authors = [{ name = "InfinityCoding", email = "infinitycoding@web.de" }]
 description = "CLI tool to create and embed ComicInfo.xml metadata for manga using AniList API"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ wheels = [
 
 [[package]]
 name = "itagger"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
This pull request introduces a new `--volume-as-number` flag to the CLI and updates the logic for mapping volume and chapter numbers to the `<Number>` tag in `ComicInfo.xml` files. This change allows users to override the default behavior and populate the `<Number>` tag with the volume number, improving compatibility with legacy or non-standard readers. The documentation and help texts have been updated to explain this new behavior.

**Feature: Enhanced Volume/Chapter Tag Mapping**

* Added a `--volume-as-number` flag to the `generate`, `batch`, and `embed` CLI commands, allowing users to map the volume number to the `<Number>` tag for legacy compatibility. [[1]](diffhunk://#diff-1bf88a77565fe4f901ac20394ea8be9b5ef3a972ecfe5c9620236a28d83c2c32L64-R67) [[2]](diffhunk://#diff-1bf88a77565fe4f901ac20394ea8be9b5ef3a972ecfe5c9620236a28d83c2c32L104-R110) [[3]](diffhunk://#diff-1bf88a77565fe4f901ac20394ea8be9b5ef3a972ecfe5c9620236a28d83c2c32R207-R217)
* Updated the `ComicInfoGenerator` so that the `<Number>` tag is set to the chapter number by default, and to the volume number only when `--volume-as-number` is specified. [[1]](diffhunk://#diff-3d762b4223593baeae0782a3c90daa5cf0deeecf31218c6fc9248308166f51feR74) [[2]](diffhunk://#diff-3d762b4223593baeae0782a3c90daa5cf0deeecf31218c6fc9248308166f51feR106-R114) [[3]](diffhunk://#diff-3d762b4223593baeae0782a3c90daa5cf0deeecf31218c6fc9248308166f51feR213-R216) [[4]](diffhunk://#diff-1bf88a77565fe4f901ac20394ea8be9b5ef3a972ecfe5c9620236a28d83c2c32L143-R149) [[5]](diffhunk://#diff-1bf88a77565fe4f901ac20394ea8be9b5ef3a972ecfe5c9620236a28d83c2c32L283-R299)

**Documentation Updates**

* Expanded the user guide and CLI documentation to explain the new flag, the default mapping of `<Number>` and `<Volume>`, and how to override the behavior for legacy readers. [[1]](diffhunk://#diff-83b878530b008fbd53fa0f5bf556c4a440db261b9a5fdcf72ad70ac0c1620dd7R117-R134) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R111) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L191-R197)

**Other Improvements**

* Bumped the package version to `0.1.4` in `pyproject.toml`.
* Minor import ordering cleanup in `itagger/cli.py`.